### PR TITLE
Config.uk: Add Musl dependency

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -5,8 +5,7 @@ menuconfig LIBMICROPYTHON
 	   select LWIP_NOTHREADS
 	   select LWIP_IGMP
 	   select LIBUKMMAP
-	   select LIBNEWLIBC
-	   select LIBUKSIGNAL
+	   select LIBMUSL
 
 if LIBMICROPYTHON
 config LIBMICROPYTHON_MAIN_FUNCTION


### PR DESCRIPTION
Use `musl` instead of `newlibc`. Also remove `uksignal` dependency.