### PR TITLE
Adapt memory region usage in patch

### DIFF
--- a/patches/0004-adapt-main-c-to-unikraft.patch
+++ b/patches/0004-adapt-main-c-to-unikraft.patch
@@ -22,10 +22,10 @@
 -            ret = execute_from_lexer(LEX_SRC_STDIN, NULL, MP_PARSE_FILE_INPUT, false);
 -        }
 +    /* see if script is available from initrd */
-+    struct ukplat_memregion_desc img;
++    struct ukplat_memregion_desc *img;
 +    char *cstr;
 +    if (ukplat_memregion_find_initrd0(&img) >= 0) {
-+      cstr = (char *)img.base;
++      cstr = (char *)img->vbase;
 +      ret = do_str(cstr);
 +    }
 +    /* repl mode */


### PR DESCRIPTION
With refactoring the boot code the memory region descriptor needed to be changed. This PR adapts the patch to work with the new version.
