### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "micropython"
+description := "An implementation of Python 3.x for microcontrollers and small embedded systems."
+gitrepo     := "https://github.com/micropython/micropython.git"
+homepage    := "http://www.micropython.org"
+license     := "BSD-3.0-Clause"
+version     := 1.9.2 sha256:1e4b4462e474c24e494192d26fd1e55f26357e261b24e483faa1089f2b0ae51e http://micropython.org/resources/source/micropython-1.9.2.zip


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

